### PR TITLE
WIP: Hyperlink schedule to lessons

### DIFF
--- a/_includes/lc/schedule.html
+++ b/_includes/lc/schedule.html
@@ -4,9 +4,10 @@
     <table class="table table-striped">
       <tr> <td>10:00</td>  <td>Arrival, Time for setup questions</td> </tr>
       <tr> <td>11:00</td>  <td>Introduction, Jargon Busting</td> </tr>
-      <tr> <td>11:30</td>  <td>OpenRefine</td> </tr>
+      <tr> <td>11:30</td>  <td><a href="https://librarycarpentry.github.io/lc-open-refine/
+        ">OpenRefine</a></td> </tr>
       <tr> <td>13:00</td>  <td>Lunch break</td> </tr>
-      <tr> <td>14:00</td>  <td>Python 1</td> </tr>
+      <tr> <td>14:00</td>  <td><a href="https://librarycarpentry.github.io/lc-python-intro/">Python 1</a></td> </tr>
       <tr> <td>16:00</td>  <td>Coffee</td> </tr>
       <tr> <td>16:30</td>  <td>Python 2</td> </tr>
       <tr> <td>18:00</td>  <td>END</td> </tr>


### PR DESCRIPTION
Während wir die Lessons abarbeiten, könnten wir den Schedule mit diesen Links versehen, damit nicht das HackMD alles aufnehmen muss. Dort würde ich lieber nur nicht-Standard-Kram sammeln.